### PR TITLE
fix ZBX_RESP_REGEX

### DIFF
--- a/module/protobix/senderprotocol.py
+++ b/module/protobix/senderprotocol.py
@@ -9,7 +9,7 @@ from senderexception import SenderException
 
 ZBX_HDR = "ZBXD\1"
 ZBX_HDR_SIZE = 13
-ZBX_RESP_REGEX = r'Processed (\d+) Failed (\d+) Total (\d+) Seconds spent (\d\.\d+)'
+ZBX_RESP_REGEX = r'processed: (\d+); failed: (\d+); total: (\d+); seconds spent: (\d\.\d+)'
 ZBX_DBG_SEND_RESULT = "DBG - Send result [%s] for [%s %s %s]"
 
 def recv_all(sock):


### PR DESCRIPTION
On Zabbix 2.4.4 (I have no other version to test).

Fix for regex not matching, partial stack trace:

```
 File "/usr/local/lib/python2.7/dist-packages/protobix/senderprotocol.py", line 109, in single_send
    result = regex.group(1)
AttributeError: 'NoneType' object has no attribute 'group'
```

Line 108, zbx_answer.get('info') returns:

```
processed: 1; failed: 0; total: 1; seconds spent: 0.000069
```

(does not match zabbix_sender doc. https://www.zabbix.com/documentation/2.4/manual/concepts/sender)

fixed ZBX_RESP_REGEX to accommodate for colons, semicolons, and case.
